### PR TITLE
Updated Intellisense to reference OkResult

### DIFF
--- a/src/System.Web.Http/Results/OkResult.cs
+++ b/src/System.Web.Http/Results/OkResult.cs
@@ -13,14 +13,14 @@ namespace System.Web.Http.Results
     {
         private readonly StatusCodeResult.IDependencyProvider _dependencies;
 
-        /// <summary>Initializes a new instance of the <see cref="NotFoundResult"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="OkResult"/> class.</summary>
         /// <param name="request">The request message which led to this result.</param>
         public OkResult(HttpRequestMessage request)
             : this(new StatusCodeResult.DirectDependencyProvider(request))
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="NotFoundResult"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="OkResult"/> class.</summary>
         /// <param name="controller">The controller from which to obtain the dependencies needed for execution.</param>
         public OkResult(ApiController controller)
             : this(new StatusCodeResult.ApiControllerDependencyProvider(controller))


### PR DESCRIPTION
The Intellisense was previously incorrect and pointed to the `NotFoundResult` class.