### PR TITLE
Update AntiForgeryWorker.cs

### DIFF
--- a/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
+++ b/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
@@ -103,7 +103,10 @@ namespace System.Web.Helpers.AntiXsrf
                 // Adding X-Frame-Options header to prevent ClickJacking. See
                 // http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-10
                 // for more information.
-                httpContext.Response.AddHeader("X-Frame-Options", "SAMEORIGIN");
+                if (Request.Headers["X-Frame-Options"] == null)
+                {
+                    httpContext.Response.AddHeader("X-Frame-Options", "SAMEORIGIN");
+                }
             }
 
             // <input type="hidden" name="__AntiForgeryToken" value="..." />


### PR DESCRIPTION
the header should be checked for existence prior to adding it. This can lead to needlessly adding it multiple times.