### PR TITLE
Fix nullref in ContextUtil

### DIFF
--- a/test/System.Web.Http.Integration.Test/Util/ContextUtil.cs
+++ b/test/System.Web.Http.Integration.Test/Util/ContextUtil.cs
@@ -58,7 +58,7 @@ namespace System.Web.Http
 
             if (descriptor.Configuration == null)
             {
-                descriptor.Configuration = controllerContext.Configuration;
+                descriptor.Configuration = context.Configuration;
             }
 
             if (context.ControllerDescriptor == null)


### PR DESCRIPTION
If you don't supply a controllerContext to the CreateActionContext method, you will get a null reference exception on line 69 when attempting to copy the Configuration property to the descriptor.