### PR TITLE
lowercase supplied origins per RFC6454

### DIFF
--- a/src/System.Web.Http.Cors/EnableCorsAttribute.cs
+++ b/src/System.Web.Http.Cors/EnableCorsAttribute.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,7 +57,7 @@ namespace System.Web.Http.Cors
             }
             else
             {
-                AddCommaSeparatedValuesToCollection(origins, _corsPolicy.Origins);
+                AddCommaSeparatedValuesToCollection(origins.ToLowerInvariant(), _corsPolicy.Origins); //scheme and host should be lowercased per rfc6454 to make the origin triple (scheme, host, port)
             }
 
             if (!String.IsNullOrEmpty(headers))


### PR DESCRIPTION
Lowercase scheme and host of origins.
 - Many browsers (clients) typically follow RFC 6454 and lower case the scheme and host members of the origin triple. See https://tools.ietf.org/html/rfc6454 § 4.2 and 4.5

Equivalent of :
https://github.com/aspnet/CORS/pull/170